### PR TITLE
fix: remove panic on intializtion

### DIFF
--- a/crates/notan_app/src/backend.rs
+++ b/crates/notan_app/src/backend.rs
@@ -64,7 +64,7 @@ pub trait BackendSystem: Backend {
     }
 
     /// Returns the graphics backend implementation
-    fn get_graphics_backend(&self) -> Box<dyn DeviceBackend>;
+    fn get_graphics_backend(&self) -> Result<Box<dyn DeviceBackend>, String>;
 
     #[cfg(feature = "audio")]
     /// Return the audio backend implementation

--- a/crates/notan_app/src/builder.rs
+++ b/crates/notan_app/src/builder.rs
@@ -233,7 +233,8 @@ where
 
         let initialize = backend.initialize(window)?;
 
-        let mut graphics = Graphics::new(backend.get_graphics_backend())?;
+        let graphics_backend = backend.get_graphics_backend()?;
+        let mut graphics = Graphics::new(graphics_backend)?;
 
         #[cfg(feature = "audio")]
         let audio = Audio::new(backend.get_audio_backend())?;

--- a/crates/notan_app/src/empty.rs
+++ b/crates/notan_app/src/empty.rs
@@ -182,8 +182,8 @@ impl BackendSystem for EmptyBackend {
         }))
     }
 
-    fn get_graphics_backend(&self) -> Box<dyn DeviceBackend> {
-        Box::<EmptyDeviceBackend>::default()
+    fn get_graphics_backend(&self) -> Result<Box<dyn DeviceBackend>, String> {
+        Ok(Box::<EmptyDeviceBackend>::default())
     }
 
     #[cfg(feature = "audio")]

--- a/crates/notan_glow/src/utils.rs
+++ b/crates/notan_glow/src/utils.rs
@@ -7,12 +7,19 @@ pub(crate) fn create_gl_context(
     antialias: bool,
     transparent: bool,
 ) -> Result<(glow::Context, String), String> {
-    if let Ok(ctx) = create_webgl2_context(win, antialias, transparent) {
-        return Ok((ctx, "webgl2".to_string()));
+    let mut errors = vec![];
+
+    match create_webgl2_context(win, antialias, transparent) {
+        Ok(ctx) => return Ok((ctx, "webgl2".to_string())),
+        Err(e) => errors.push(e),
     }
 
-    let ctx = create_webgl_context(win, antialias, transparent)?;
-    Ok((ctx, "webgl".to_string()))
+    match create_webgl_context(win, antialias, transparent) {
+        Ok(ctx) => return Ok((ctx, "webgl".to_string())),
+        Err(e) => errors.push(e),
+    }
+
+    Err(format!("Failed to create WebGL context: {errors:?}"))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/notan_glow/src/utils.rs
+++ b/crates/notan_glow/src/utils.rs
@@ -34,10 +34,10 @@ fn create_webgl_context(
     //TODO manage errors
     let gl = win
         .get_context_with_context_options("webgl", webgl_options(antialias, transparent).as_ref())
-        .unwrap()
-        .unwrap()
+        .map_err(|e| format!("Failed to create WebGL context: {e:?}"))?
+        .ok_or_else(|| format!("Failed to create WebGL context"))?
         .dyn_into::<web_sys::WebGlRenderingContext>()
-        .unwrap();
+        .map_err(|e| format!("Failed to cast the context to WebGL context: {e:?}"))?;
 
     let ctx = glow::Context::from_webgl1_context(gl);
     Ok(ctx)
@@ -52,10 +52,10 @@ fn create_webgl2_context(
     //TODO manage errors
     let gl = win
         .get_context_with_context_options("webgl2", webgl_options(antialias, transparent).as_ref())
-        .unwrap()
-        .unwrap()
+        .map_err(|e| format!("Failed to create WebGL2 context: {e:?}"))?
+        .ok_or_else(|| format!("Failed to create WebGL2 context"))?
         .dyn_into::<web_sys::WebGl2RenderingContext>()
-        .unwrap();
+        .map_err(|e| format!("Failed to cast the context to WebGL2 context: {e:?}"))?;
 
     let ctx = glow::Context::from_webgl2_context(gl);
     Ok(ctx)

--- a/crates/notan_web/src/backend.rs
+++ b/crates/notan_web/src/backend.rs
@@ -112,10 +112,12 @@ impl BackendSystem for WebBackend {
         }))
     }
 
-    fn get_graphics_backend(&self) -> Box<dyn DeviceBackend> {
-        let win = self.window.as_ref().unwrap();
-        let backend =
-            notan_glow::GlowBackend::new(&win.canvas, win.antialias, win.transparent).unwrap();
+    fn get_graphics_backend(&self) -> Result<Box<dyn DeviceBackend>, String> {
+        let win = self
+            .window
+            .as_ref()
+            .ok_or(Err("Failed to get window backend".into()))?;
+        let backend = notan_glow::GlowBackend::new(&win.canvas, win.antialias, win.transparent)?;
         Box::new(backend)
     }
 

--- a/crates/notan_winit/src/backend.rs
+++ b/crates/notan_winit/src/backend.rs
@@ -293,14 +293,19 @@ impl BackendSystem for WinitBackend {
         }))
     }
 
-    fn get_graphics_backend(&self) -> Box<dyn DeviceBackend> {
-        let ctx = &self.window.as_ref().unwrap().gl_manager.display;
+    fn get_graphics_backend(&self) -> Result<Box<dyn DeviceBackend>, String> {
+        let ctx = &self
+            .window
+            .as_ref()
+            .ok_or_else(|| "Failed to get window ref")?
+            .gl_manager
+            .display;
         let backend = notan_glow::GlowBackend::new(|s| {
             let symbol = CString::new(s).unwrap();
             ctx.get_proc_address(symbol.as_c_str()).cast()
-        })
-        .unwrap();
-        Box::new(backend)
+        })?;
+
+        Ok(Box::new(backend))
     }
 
     #[cfg(feature = "audio")]


### PR DESCRIPTION
This PR removes `.unwrap()` in app initialization. e.g.) WebGL context error.
This will reduce the possibility of panics during engine restart.