### PR TITLE
perf: avoid checkFramebufferStatus

### DIFF
--- a/crates/notan_glow/src/render_target.rs
+++ b/crates/notan_glow/src/render_target.rs
@@ -80,12 +80,16 @@ unsafe fn create_fbo(
         _ => None,
     };
 
-    let status = gl.check_framebuffer_status(glow::FRAMEBUFFER);
-    if status != glow::FRAMEBUFFER_COMPLETE {
-        return Err(
-            "Cannot create a render target because the framebuffer is incomplete...".to_string(),
-        );
-    }
+    // Since gl.checkFramebufferStatus causes GPU stall, we commented out these line.
+    // If the framebuffer isn't complete we can't render correctly anyway, so it's safe to skip this.
+    // ref. https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_blocking_api_calls_in_production
+    //
+    // let status = gl.check_framebuffer_status(glow::FRAMEBUFFER);
+    // if status != glow::FRAMEBUFFER_COMPLETE {
+    //     return Err(
+    //         "Cannot create a render target because the framebuffer is incomplete...".to_string(),
+    //     );
+    // }
 
     // transparent clear to avoid weird visual glitches
     clear(gl, &Some(Color::TRANSPARENT), &None, &None);

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -370,11 +370,9 @@ impl WindowBackend for WebWindowBackend {
     fn set_position(&mut self, _x: i32, _y: i32) {}
 
     fn set_size(&mut self, width: i32, height: i32) {
-        if width != self.config.width || height != self.config.height {
-            set_size_dpi(&self.canvas, width as _, height as _);
-            self.config.width = width;
-            self.config.height = height;
-        }
+        set_size_dpi(&self.canvas, width as _, height as _);
+        self.config.width = width;
+        self.config.height = height;
     }
 
     fn set_visible(&mut self, visible: bool) {

--- a/crates/notan_web/src/window.rs
+++ b/crates/notan_web/src/window.rs
@@ -370,9 +370,11 @@ impl WindowBackend for WebWindowBackend {
     fn set_position(&mut self, _x: i32, _y: i32) {}
 
     fn set_size(&mut self, width: i32, height: i32) {
-        set_size_dpi(&self.canvas, width as _, height as _);
-        self.config.width = width;
-        self.config.height = height;
+        if width != self.config.width || height != self.config.height {
+            set_size_dpi(&self.canvas, width as _, height as _);
+            self.config.width = width;
+            self.config.height = height;
+        }
     }
 
     fn set_visible(&mut self, visible: bool) {


### PR DESCRIPTION
![image](https://github.com/invideoio/notan/assets/1403842/18f782f6-5e80-4dde-9fa4-c4f470349f6a)

This PR disables `gl.checkFramebufferStatus()`.
This function is called every time we allocate a new RenderTexture, checking if the framebuffer is "complete".

However, this causes a huge GPU stall on low-end devices...
Mozilla's doc recommends to avoid using this on prod.
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices#avoid_blocking_api_calls_in_production

If the buffer is incomplete, we just can't render the frame anyway, and there's no way to recover. 
So I believe we can skip this.
