### PR TITLE
feat: support GL_POINTS

### DIFF
--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -376,7 +376,19 @@ impl GlowBackend {
         }
     }
 
+    fn set_program_point_size(&self, primitive: &DrawPrimitive) {
+        #[cfg(not(target_arch = "wasm32"))]
+        unsafe {
+            if matches!(primitive, DrawPrimitive::Points) {
+                self.gl.enable(glow::PROGRAM_POINT_SIZE);
+            } else {
+                self.gl.disable(glow::PROGRAM_POINT_SIZE);
+            }
+        }
+    }
+
     fn draw(&mut self, primitive: &DrawPrimitive, offset: i32, count: i32) {
+        self.set_program_point_size(primitive);
         unsafe {
             self.stats.draw_calls += 1;
             match self.using_indices {
@@ -389,6 +401,7 @@ impl GlowBackend {
         }
     }
     fn draw_instanced(&mut self, primitive: &DrawPrimitive, offset: i32, count: i32, length: i32) {
+        self.set_program_point_size(primitive);
         unsafe {
             self.stats.draw_calls += 1;
             match self.using_indices {

--- a/crates/notan_glow/src/lib.rs
+++ b/crates/notan_glow/src/lib.rs
@@ -377,7 +377,7 @@ impl GlowBackend {
     }
 
     fn set_program_point_size(&self, primitive: &DrawPrimitive) {
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(not(target_arch = "wasm32"), not(target_os = "ios"), not(target_os = "android")))]
         unsafe {
             if matches!(primitive, DrawPrimitive::Points) {
                 self.gl.enable(glow::PROGRAM_POINT_SIZE);

--- a/crates/notan_glow/src/to_glow.rs
+++ b/crates/notan_glow/src/to_glow.rs
@@ -140,6 +140,7 @@ impl ToGlow for DrawPrimitive {
             DrawPrimitive::TriangleStrip => glow::TRIANGLE_STRIP,
             DrawPrimitive::Lines => glow::LINES,
             DrawPrimitive::LineStrip => glow::LINE_STRIP,
+            DrawPrimitive::Points => glow::POINTS,
         }
     }
 }

--- a/crates/notan_graphics/src/pipeline.rs
+++ b/crates/notan_graphics/src/pipeline.rs
@@ -438,6 +438,7 @@ impl Default for StencilOptions {
 pub enum DrawPrimitive {
     Lines,
     LineStrip,
+    Points,
     #[default]
     Triangles,
     TriangleStrip,


### PR DESCRIPTION
This PR allows us to draw points as GL_POINTS, useful for histogram / waveform shaders.